### PR TITLE
fix remove for collections on client to use oid

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -173,7 +173,7 @@
                 });
 
                 Omni.connection.on("remove:" + collectionName, function(data) {
-                    Omni.collections[collectionName].remove(data.id, {fromServer: true});
+                    Omni.collections[collectionName].remove(data.oid, {fromServer: true});
                 });
             })(collectionName, modelName);
         }


### PR DESCRIPTION
This should fix the problem where extra models remain in a collection on the client, even when they are removed from the server.
